### PR TITLE
Add controller support for @AsyncApiService decorator

### DIFF
--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Logger } from '@nestjs/common';
+import { AsyncApiPub, AsyncApiService } from '../../../lib';
+import { AsyncApiSub } from '../../../lib/decorators/asyncapi-operation.decorator';
+import { CreateCatCommand } from './async/messages';
+
+@AsyncApiService()
+@Controller()
+export class CatsController {
+  private logger: Logger = new Logger(CatsController.name);
+
+  @AsyncApiSub({
+    channel: 'test-controller',
+    summary: 'Subscribe to events on this topic',
+    description: 'method is used for test purposes',
+    message: {
+      name: 'test event',
+      payload: {
+        type: CreateCatCommand,
+      },
+    },
+  })
+  async handleRequestResponse() {
+    this.logger.log(`received event`);
+  }
+}

--- a/e2e/src/cats/cats.module.ts
+++ b/e2e/src/cats/cats.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CatsService } from './cats.service';
 import { CatsGateway } from './cats.gateway';
+import { CatsController } from './cats.controller';
 
 @Module({
   providers: [CatsService, CatsGateway],
+  controllers: [CatsController],
 })
 export class CatsModule {}

--- a/lib/asyncapi.scanner.ts
+++ b/lib/asyncapi.scanner.ts
@@ -30,8 +30,8 @@ export class AsyncapiScanner {
     const modules: Module[] = this.getModules(container.getModules(), includedModules);
     const globalPrefix = !ignoreGlobalPrefix ? stripLastSlash(this.getGlobalPrefix(app)) : '';
 
-    const denormalizedChannels = modules.map(({ components, metatype, relatedModules }) => {
-      let allComponents = new Map(components);
+    const denormalizedChannels = modules.map(({ components, metatype, relatedModules, routes }) => {
+      let allComponents = new Map([...components, ...routes]);
 
       if (deepScanRoutes) {
         // only load submodules routes if asked
@@ -39,9 +39,9 @@ export class AsyncapiScanner {
 
         Array.from(relatedModules.values())
           .filter(isGlobal as any)
-          .map(({ components: relatedComponents }) => relatedComponents)
-          .forEach((relatedComponents) => {
-            allComponents = new Map([...allComponents, ...relatedComponents]);
+          .map(({ components: relatedComponents, routes: relatedRoutes }) => ({ relatedComponents, relatedRoutes }))
+          .forEach(({ relatedComponents, relatedRoutes }) => {
+            allComponents = new Map([...allComponents, ...relatedComponents, ...relatedRoutes]);
           });
       }
       const path = metatype ? Reflect.getMetadata(MODULE_PATH, metatype) : undefined;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, `@AsyncApiService`, `@AsyncApiPub` and `@AsyncApiSub` decorators are ignored in controllers.

Issue Number: #25 


## What is the new behavior?
`@AsyncApiService`, `@AsyncApiPub` and `@AsyncApiSub` decorators are no longer ignored, when placed within controllers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information