### PR TITLE
Multiple decorators for one function

### DIFF
--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -19,6 +19,30 @@ export class CatsController {
       },
     },
   })
+  @AsyncApiPub(
+    {
+      channel: 'test-controller/reply',
+      summary: 'Send test packet',
+      description: 'method is used for test purposes',
+      message: {
+        name: 'test data',
+        payload: {
+          type: String,
+        },
+      },
+    },
+    {
+      channel: 'test-controller',
+      summary: 'Send test packet',
+      description: 'method is used for test purposes',
+      message: {
+        name: 'test data',
+        payload: {
+          type: String,
+        },
+      },
+    },
+  )
   async handleRequestResponse() {
     this.logger.log(`received event`);
   }

--- a/lib/asyncapi.explorer.ts
+++ b/lib/asyncapi.explorer.ts
@@ -78,42 +78,6 @@ export class AsyncApiExplorer {
           root: { ...serviceMetadata, name: channel },
           operations: channels[channel],
         }));
-
-        // const pubs = documentResolvers.operations[0](this.schemas, instance, prototype, targetCallback);
-        // const subs = documentResolvers.operations[1](this.schemas, instance, prototype, targetCallback);
-
-        // if (!pubs) {
-        //   if (!subs) {
-        //     return [];
-        //   }
-
-        //   return [subs.map(())
-        //     {
-        //       root: { ...serviceMetadata, name: sub.channel },
-        //       operations: { ...sub },
-        //     },
-        //   ];
-        // }
-
-        // if (!sub || pub.channel === sub.channel) {
-        //   return [
-        //     {
-        //       root: { ...serviceMetadata, name: pub.channel },
-        //       operations: { ...pub, ...sub },
-        //     },
-        //   ];
-        // } else {
-        //   return [
-        //     {
-        //       root: { ...serviceMetadata, name: pub.channel },
-        //       operations: { ...pub },
-        //     },
-        //     {
-        //       root: { ...serviceMetadata, name: sub.channel },
-        //       operations: { ...sub },
-        //     },
-        //   ];
-        // }
       }, []);
       return methodMetadata;
     });

--- a/lib/asyncapi.explorer.ts
+++ b/lib/asyncapi.explorer.ts
@@ -4,8 +4,9 @@ import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 
 import { DECORATORS } from './index';
-import { exploreAsyncapiOperationMetadata, exploreAsyncapiServiceMetadata } from './explorers';
+import { exploreAsyncapiPubMetadata, exploreAsyncapiServiceMetadata, exploreAsyncapiSubMetadata } from './explorers';
 import { DenormalizedDocResolvers, DenormalizedDoc } from './interfaces';
+import { flatten } from 'lodash';
 
 export class AsyncApiExplorer {
   private readonly metadataScanner = new MetadataScanner();
@@ -33,7 +34,7 @@ export class AsyncApiExplorer {
       root: [exploreAsyncapiServiceMetadata],
       security: [],
       tags: [],
-      operations: [exploreAsyncapiOperationMetadata],
+      operations: [exploreAsyncapiPubMetadata, exploreAsyncapiSubMetadata],
     };
 
     return this.generateDenormalizedDocument(metatype as Type<unknown>, prototype, instance, documentResolvers, modulePath, globalPrefix);
@@ -52,24 +53,71 @@ export class AsyncApiExplorer {
     _modulePath?: string,
     _globalPrefix?: string,
   ): DenormalizedDoc[] {
-    const denormalizedAsyncapiServices = this.metadataScanner.scanFromPrototype<any, DenormalizedDoc>(instance, prototype, (name) => {
+    const denormalizedAsyncapiServices = this.metadataScanner.scanFromPrototype<any, DenormalizedDoc[]>(instance, prototype, (name) => {
       const targetCallback = prototype[name];
       const methodMetadata = documentResolvers.root.reduce((_metadata, fn) => {
         const serviceMetadata = fn(metatype);
 
-        const operations = documentResolvers.operations.reduce((_metadata2, fn2) => {
-          return fn2(this.schemas, this.schemaRefsStack, instance, prototype, targetCallback);
+        const channels = documentResolvers.operations.reduce((operations, exploreOperationsMeta) => {
+          const meta = exploreOperationsMeta(this.schemas, instance, prototype, targetCallback);
+          if (!meta) {
+            return operations;
+          }
+
+          meta.forEach((op) => {
+            if (operations.hasOwnProperty(op.channel)) {
+              operations[op.channel] = { ...operations[op.channel], ...op };
+            } else {
+              operations[op.channel] = op;
+            }
+          });
+          return operations;
         }, {});
 
-        return {
-          root: { ...serviceMetadata, name: operations.channel },
-          operations,
-        };
-      }, {});
+        return Object.keys(channels).map((channel) => ({
+          root: { ...serviceMetadata, name: channel },
+          operations: channels[channel],
+        }));
+
+        // const pubs = documentResolvers.operations[0](this.schemas, instance, prototype, targetCallback);
+        // const subs = documentResolvers.operations[1](this.schemas, instance, prototype, targetCallback);
+
+        // if (!pubs) {
+        //   if (!subs) {
+        //     return [];
+        //   }
+
+        //   return [subs.map(())
+        //     {
+        //       root: { ...serviceMetadata, name: sub.channel },
+        //       operations: { ...sub },
+        //     },
+        //   ];
+        // }
+
+        // if (!sub || pub.channel === sub.channel) {
+        //   return [
+        //     {
+        //       root: { ...serviceMetadata, name: pub.channel },
+        //       operations: { ...pub, ...sub },
+        //     },
+        //   ];
+        // } else {
+        //   return [
+        //     {
+        //       root: { ...serviceMetadata, name: pub.channel },
+        //       operations: { ...pub },
+        //     },
+        //     {
+        //       root: { ...serviceMetadata, name: sub.channel },
+        //       operations: { ...sub },
+        //     },
+        //   ];
+        // }
+      }, []);
       return methodMetadata;
     });
 
-    // console.table(denormalizedAsyncapiServices);
-    return denormalizedAsyncapiServices;
+    return flatten(denormalizedAsyncapiServices);
   }
 }

--- a/lib/decorators/asyncapi-operation.decorator.ts
+++ b/lib/decorators/asyncapi-operation.decorator.ts
@@ -14,10 +14,10 @@ export interface AsyncOperationOptions extends Omit<AsyncOperationObject, 'messa
   };
 }
 
-export function AsyncApiPub(options: AsyncOperationOptions): MethodDecorator & ClassDecorator {
+export function AsyncApiPub(...options: AsyncOperationOptions[]): MethodDecorator & ClassDecorator {
   return createMixedDecorator(DECORATORS.ASYNCAPI_PUB, options);
 }
 
-export function AsyncApiSub(options: AsyncOperationOptions): MethodDecorator & ClassDecorator {
+export function AsyncApiSub(...options: AsyncOperationOptions[]): MethodDecorator & ClassDecorator {
   return createMixedDecorator(DECORATORS.ASYNCAPI_SUB, options);
 }

--- a/lib/explorers/asyncapi-operation.explorer.ts
+++ b/lib/explorers/asyncapi-operation.explorer.ts
@@ -13,39 +13,41 @@ export const exploreAsyncapiOperationMetadata = (
   prototype: Type<unknown>,
   method: object,
 ) => {
-  const pubMetadata: AsyncOperationOptions = exploreAsyncapiPubMetadata(instance, prototype, method);
-  const subMetadata: AsyncOperationOptions = exploreAsyncapiSubMetadata(instance, prototype, method);
-
-  let pubObject = {};
-  if (pubMetadata) {
-    pubObject = {
-      channel: pubMetadata.channel,
-      pub: {
-        ...pubMetadata,
-        ...operationObjectFactory.create(pubMetadata, ['application/json'], schemas),
-        channel: undefined,
-      },
-    };
-  }
-
-  let subObject = {};
-  if (subMetadata) {
-    subObject = {
-      channel: subMetadata.channel,
-      sub: {
-        ...subMetadata,
-        ...operationObjectFactory.create(subMetadata, ['application/json'], schemas),
-        channel: undefined,
-      },
-    };
-  }
+  const pubObject = exploreAsyncapiPubMetadata(schemas, instance, prototype, method);
+  const subObject = exploreAsyncapiSubMetadata(schemas, instance, prototype, method);
 
   return { ...pubObject, ...subObject };
 };
 
-export const exploreAsyncapiPubMetadata = (_instance: object, _prototype: Type<unknown>, method: object) => {
-  return Reflect.getMetadata(DECORATORS.ASYNCAPI_PUB, method);
+export const exploreAsyncapiPubMetadata = (schemas: Record<string, SchemaObject>, _instance: object, _prototype: Type<unknown>, method: object) => {
+  const metadata = Reflect.getMetadata(DECORATORS.ASYNCAPI_PUB, method);
+
+  if (!metadata) {
+    return;
+  }
+
+  return metadata.map((option) => ({
+    channel: option.channel,
+    pub: {
+      ...option,
+      ...operationObjectFactory.create(option, ['application/json'], schemas),
+      channel: undefined,
+    },
+  }));
 };
-export const exploreAsyncapiSubMetadata = (_instance: object, _prototype: Type<unknown>, method: object) => {
-  return Reflect.getMetadata(DECORATORS.ASYNCAPI_SUB, method);
+export const exploreAsyncapiSubMetadata = (schemas: Record<string, SchemaObject>, _instance: object, _prototype: Type<unknown>, method: object) => {
+  const metadata = Reflect.getMetadata(DECORATORS.ASYNCAPI_SUB, method);
+
+  if (!metadata) {
+    return;
+  }
+
+  return metadata.map((option) => ({
+    channel: option.channel,
+    sub: {
+      ...option,
+      ...operationObjectFactory.create(option, ['application/json'], schemas),
+      channel: undefined,
+    },
+  }));
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently it is not possible, to add an `@AsyncApiPub` and an `@AsyncApiPub` decorator with different channels to the same method. If different channels are set, they are merged into one channel for the documentation. Furthermore, it is not possible, to document multiple publish or subscribe events to different topics for the same method. 

Issue Number: #26 


## What is the new behavior?
It is possible, to add an `@AsyncApiPub` and an `@AsyncApiPub` decorator with different channels to the same method. Also, it is possible to add multiple publish or subscribe events to one method, by using the following syntax:
```ts
@AsyncApiPub({...}, {...})
```

It is still not possible, to define multiple plublish events, with the same channel, but different payloads. This is, as far as I can tell, not supported by the async api spec.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information