### PR TITLE
To be able to set Sub and Pub decorators together for same method

### DIFF
--- a/lib/decorators/asyncapi-operation.decorator.ts
+++ b/lib/decorators/asyncapi-operation.decorator.ts
@@ -41,6 +41,10 @@ function makeMessage(
 export function AsyncApiOperation(
   ...options: AsyncApiOperationOptions[]
 ): MethodDecorator {
+  return AsyncApiOperationForMetaKey(DECORATORS.AsyncApiOperation, options)
+}
+
+export function AsyncApiOperationForMetaKey(metaKey: string, options: AsyncApiOperationOptions[]) {
   return (target, propertyKey: string | symbol, descriptor) => {
     const methodName = `${target.constructor.name}#${String(propertyKey)}`;
 
@@ -62,7 +66,7 @@ export function AsyncApiOperation(
     });
 
     return createMethodDecorator(
-      DECORATORS.AsyncApiOperation,
+      metaKey,
       transformedOptions,
     )(target, propertyKey, descriptor);
   };

--- a/lib/decorators/asyncapi-operation.decorator.ts
+++ b/lib/decorators/asyncapi-operation.decorator.ts
@@ -38,13 +38,10 @@ function makeMessage(
   };
 }
 
-export function AsyncApiOperation(
-  ...options: AsyncApiOperationOptions[]
+export function AsyncApiOperationForMetaKey(
+  metaKey: string,
+  options: AsyncApiOperationOptions[],
 ): MethodDecorator {
-  return AsyncApiOperationForMetaKey(DECORATORS.AsyncApiOperation, options)
-}
-
-export function AsyncApiOperationForMetaKey(metaKey: string, options: AsyncApiOperationOptions[]) {
   return (target, propertyKey: string | symbol, descriptor) => {
     const methodName = `${target.constructor.name}#${String(propertyKey)}`;
 
@@ -65,9 +62,16 @@ export function AsyncApiOperationForMetaKey(metaKey: string, options: AsyncApiOp
       return transformedOptionInstance;
     });
 
-    return createMethodDecorator(
-      metaKey,
-      transformedOptions,
-    )(target, propertyKey, descriptor);
+    return createMethodDecorator(metaKey, transformedOptions)(
+      target,
+      propertyKey,
+      descriptor,
+    );
   };
+}
+
+export function AsyncApiOperation(
+  ...options: AsyncApiOperationOptions[]
+): MethodDecorator {
+  return AsyncApiOperationForMetaKey(DECORATORS.AsyncApiOperation, options);
 }

--- a/lib/decorators/asyncapi-pub.decorator.ts
+++ b/lib/decorators/asyncapi-pub.decorator.ts
@@ -1,8 +1,9 @@
+import { DECORATORS } from 'lib/asyncapi.constants';
 import {
   AsyncApiOperationOptions,
   AsyncApiSpecificOperationOptions,
 } from '../interface';
-import { AsyncApiOperation } from './asyncapi-operation.decorator';
+import { AsyncApiOperationForMetaKey } from './asyncapi-operation.decorator';
 
 export function AsyncApiPub(
   ...specificOperationOptions: AsyncApiSpecificOperationOptions[]
@@ -13,5 +14,5 @@ export function AsyncApiPub(
       type: 'pub',
     }),
   );
-  return AsyncApiOperation(...options);
+  return AsyncApiOperationForMetaKey(DECORATORS.AsyncApiPub, options);
 }

--- a/lib/decorators/asyncapi-pub.decorator.ts
+++ b/lib/decorators/asyncapi-pub.decorator.ts
@@ -1,4 +1,4 @@
-import { DECORATORS } from 'lib/asyncapi.constants';
+import { DECORATORS } from '../asyncapi.constants';
 import {
   AsyncApiOperationOptions,
   AsyncApiSpecificOperationOptions,

--- a/lib/decorators/asyncapi-sub.decorator.ts
+++ b/lib/decorators/asyncapi-sub.decorator.ts
@@ -1,8 +1,9 @@
+import { DECORATORS } from 'lib/asyncapi.constants';
 import {
   AsyncApiOperationOptions,
   AsyncApiSpecificOperationOptions,
 } from '../interface';
-import { AsyncApiOperation } from './asyncapi-operation.decorator';
+import { AsyncApiOperationForMetaKey } from './asyncapi-operation.decorator';
 
 export function AsyncApiSub(
   ...specificOperationOptions: AsyncApiSpecificOperationOptions[]
@@ -13,5 +14,5 @@ export function AsyncApiSub(
       type: 'sub',
     }),
   );
-  return AsyncApiOperation(...options);
+  return AsyncApiOperationForMetaKey(DECORATORS.AsyncApiSub, options);
 }

--- a/lib/decorators/asyncapi-sub.decorator.ts
+++ b/lib/decorators/asyncapi-sub.decorator.ts
@@ -1,4 +1,4 @@
-import { DECORATORS } from 'lib/asyncapi.constants';
+import { DECORATORS } from '../asyncapi.constants';
 import {
   AsyncApiOperationOptions,
   AsyncApiSpecificOperationOptions,

--- a/lib/explorers/asyncapi-operation.explorer.ts
+++ b/lib/explorers/asyncapi-operation.explorer.ts
@@ -12,10 +12,10 @@ export const exploreAsyncApiOperationMetadata = (
   _prototype: Type<unknown>,
   method: object,
 ) => {
-  const metadata = Reflect.getMetadata(DECORATORS.AsyncApiOperation, method);
-  const metadataSub = Reflect.getMetadata(DECORATORS.AsyncApiSub, method);
-  const metadataPub = Reflect.getMetadata(DECORATORS.AsyncApiPub, method);
-  const metadataCombined = [...metadata || [], ...metadataSub || [], ...metadataPub || []]
+  const metadataOperations: AsyncApiOperationOptionsRaw[] = Reflect.getMetadata(DECORATORS.AsyncApiOperation, method);
+  const metadataSubs: AsyncApiOperationOptionsRaw[] = Reflect.getMetadata(DECORATORS.AsyncApiSub, method);
+  const metadataPubs: AsyncApiOperationOptionsRaw[] = Reflect.getMetadata(DECORATORS.AsyncApiPub, method);
+  const metadataCombined = [...metadataOperations || [], ...metadataSubs || [], ...metadataPubs || []]
 
   return metadataCombined.map((option: AsyncApiOperationOptionsRaw) => {
     const { channel, type } = option;

--- a/lib/explorers/asyncapi-operation.explorer.ts
+++ b/lib/explorers/asyncapi-operation.explorer.ts
@@ -12,16 +12,12 @@ export const exploreAsyncApiOperationMetadata = (
   _prototype: Type<unknown>,
   method: object,
 ) => {
-  const metadata: AsyncApiOperationOptionsRaw[] = Reflect.getMetadata(
-    DECORATORS.AsyncApiOperation,
-    method,
-  );
+  const metadata = Reflect.getMetadata(DECORATORS.AsyncApiOperation, method);
+  const metadataSub = Reflect.getMetadata(DECORATORS.AsyncApiSub, method);
+  const metadataPub = Reflect.getMetadata(DECORATORS.AsyncApiPub, method);
+  const metadataCombined = [...metadata || [], ...metadataSub || [], ...metadataPub || []]
 
-  if (!metadata) {
-    return;
-  }
-
-  return metadata.map((option: AsyncApiOperationOptionsRaw) => {
+  return metadataCombined.map((option: AsyncApiOperationOptionsRaw) => {
     const { channel, type } = option;
 
     const methodTypeData = {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
This PR address this issue, that was initially evaluated as feature. https://github.com/flamewow/nestjs-asyncapi/issues/465

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 465


## What is the new behavior?
AsyncApiPub and AsyncApiSub decorators now creates method decorator with different meta keys 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information