### PR TITLE
Changed to allow overlapping use when using `@AsyncApiSub` / `@AsyncApiPub`

### DIFF
--- a/lib/decorators/asyncapi-operation-for-meta-key.decorator.ts
+++ b/lib/decorators/asyncapi-operation-for-meta-key.decorator.ts
@@ -42,6 +42,9 @@ export function AsyncApiOperationForMetaKey(
   options: AsyncApiOperationOptions[],
 ): MethodDecorator {
   return (target, propertyKey: string | symbol, descriptor) => {
+    const savedOptions: Record<string, AsyncOperationObject> | undefined =
+      Reflect.getMetadata(metaKey, target[propertyKey]);
+
     const methodName = `${target.constructor.name}#${String(propertyKey)}`;
 
     const transformedOptions: AsyncOperationObject[] = options.map((i) => {
@@ -61,7 +64,11 @@ export function AsyncApiOperationForMetaKey(
       return transformedOptionInstance;
     });
 
-    return createMethodDecorator(metaKey, transformedOptions)(
+    let lastOptions = transformedOptions;
+    if (savedOptions)
+      lastOptions = [...Object.values(savedOptions), ...lastOptions];
+
+    return createMethodDecorator(metaKey, lastOptions)(
       target,
       propertyKey,
       descriptor,

--- a/sample/felines/felines.gateway.ts
+++ b/sample/felines/felines.gateway.ts
@@ -17,6 +17,7 @@ import { AsyncApiPub, AsyncApiSub } from '#lib';
 
 const EventPatternsWS = {
   createFeline: 'ws/create/feline',
+  wantFeline: 'ws/want/feline',
 };
 
 /**
@@ -69,6 +70,12 @@ export class FelinesGateway implements OnGatewayInit, OnGatewayDisconnect {
         payload: FelineExtendedRto,
       },
     ],
+  })
+  @AsyncApiSub({
+    channel: EventPatternsWS.wantFeline,
+    message: {
+      payload: FelineRto,
+    },
   })
   async emitCreatedFeline(felineRto: FelineRto) {
     this.server.emit(EventPatternsWS.createFeline, felineRto);


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using multiple `@AsyncApiPub` or `@AsyncApiSub` in one method, only the last document data is applied.

**gateway**
![image](https://github.com/flamewow/nestjs-asyncapi/assets/20502624/3ba3e7fb-a883-4618-8c31-7f9ef02403bf)

**docs**
![image](https://github.com/flamewow/nestjs-asyncapi/assets/20502624/fb05059d-c8ca-4c71-a197-1e7c2e814ce4)


## What is the new behavior?

If multiple `@AsyncApiPub` or `@AsyncApiSub` are used in one method, all applied document data is applied.

**docs**
![image](https://github.com/flamewow/nestjs-asyncapi/assets/20502624/b25fd145-b8f8-4adf-83a6-3aad83b3012b)



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information