### PR TITLE
docs: correct AsyncApi class decorator documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ async function bootstrap() {
 
 AsyncApi module explores `Controllers` & `WebSocketGateway` by default.
 In most cases you won't need to add extra annotation,
-but if you need to define asyncApi operations in a class that's not a controller or gateway use `AsyncApiClass`
+but if you need to define asyncApi operations in a class that's not a controller or gateway use the `AsyncApi` class
 decorator.
 
 Mark pub/sub methods via `AsyncApiPub` or `AsyncApiSub` decorators<br/>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Other... Please describe: docs
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Readme currently makes it seem like I should use a decorator "AsyncApiClass" to indicate a class that has async API content. In actuality, the decorator to use is "AsyncApi"

Issue Number: N/A


## What is the new behavior?

Documentation reflects code

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information